### PR TITLE
Add URL formatting

### DIFF
--- a/src/server/routes/shorturls.ts
+++ b/src/server/routes/shorturls.ts
@@ -3,6 +3,8 @@ import * as fp from 'fastify-plugin';
 import * as http from 'http';
 import * as getUUID from 'uuid-by-string';
 
+import { formatURL } from '../utils';
+
 export default fp(async (server, opts, next) => {
   /**
    * GET /api/shorturls/:shortURL
@@ -69,9 +71,10 @@ export default fp(async (server, opts, next) => {
   ) => {
     try {
       const redirectURL = request.body.redirectURL;
+      const formattedRedirectURL = formatURL(redirectURL);
       const shortURL = getUUID(redirectURL);
 
-      await server.redis.set(shortURL, redirectURL);
+      await server.redis.set(shortURL, formattedRedirectURL);
 
       return reply
         .code(201)

--- a/src/server/utils/__tests__/url.spec.ts
+++ b/src/server/utils/__tests__/url.spec.ts
@@ -1,0 +1,14 @@
+import * as url from '../url';
+
+describe('formatURL', () => {
+  it('should not prepend HTTP protocol', () => {
+    const rawURL = 'http://website.com';
+    const formatted = url.formatURL(rawURL);
+    expect(formatted).toEqual(rawURL);
+  });
+
+  it('should prepend HTTP protocol', () => {
+    const formatted = url.formatURL('website.com');
+    expect(formatted).toEqual('http://website.com');
+  });
+});

--- a/src/server/utils/index.ts
+++ b/src/server/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './url';

--- a/src/server/utils/url.ts
+++ b/src/server/utils/url.ts
@@ -1,0 +1,17 @@
+import { parse as parseURL } from 'url';
+
+/**
+ * Format misspelled URLs.
+ * Will only prepend HTTP protocol if missing for now.
+ * @param {string} rawURL e.g. website.com, http://website.com
+ * @return {string}
+ */
+export function formatURL(rawURL: string): string {
+  const parsed = parseURL(rawURL);
+
+  if (!!parsed.protocol) {
+    return rawURL;
+  }
+
+  return `http://${rawURL}`;
+}


### PR DESCRIPTION
Add simple URL formatting to reformat users' URLs without protocols, e.g. `google.com`.